### PR TITLE
add LuaMessage::ThreadYield message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-/target
+target
 **/*.rs.bk
 Cargo.lock
 .idea
 actix-lua.iml
-examples/http-server/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.1"
 tokio = "0.1"
 rlua = "0.14"
 uuid = { version = "0.6", features = ["v4"] }
+regex = "1"
 
 [dev-dependencies]
 futures-timer = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! [`LuaActorBuilder`]: struct.LuaActorBuilder.html
 //! [`LuaMessage`]: enum.LuaMessage.html
 extern crate actix;
+extern crate regex;
 extern crate rlua;
 extern crate tokio;
 extern crate uuid;

--- a/src/lua/prelude.lua
+++ b/src/lua/prelude.lua
@@ -1,4 +1,5 @@
 __threads = {}
+__thread_id_seq = 0
 __scripts = {}
 
 ctx = { state = {} }
@@ -13,7 +14,8 @@ end
 
 -- create a new coroutine from given script
 function __run(script_name, msg, thread_id)
-    ctx.thread_id = thread_id
+    ctx.thread_id = __thread_id_seq
+    __thread_id_seq = __thread_id_seq + 1
 
     ctx.notify = notify
     ctx.notify_later = notify_later

--- a/src/lua/prelude.lua
+++ b/src/lua/prelude.lua
@@ -1,5 +1,4 @@
 __threads = {}
-__thread_id_seq = 0
 __scripts = {}
 
 ctx = { state = {} }
@@ -13,18 +12,17 @@ function __load(script, name)
 end
 
 -- create a new coroutine from given script
-function __run(script_name, msg)
-    ctx.thread_id = __thread_id_seq
-    __thread_id_seq = __thread_id_seq + 1
+function __run(script_name, msg, thread_id)
+    ctx.thread_id = thread_id
 
     ctx.notify = notify
     ctx.notify_later = notify_later
     ctx.new_actor = function (path)
-        return __new_actor(path, ctx.thread_id)
+        return __new_actor(path)
     end
     ctx.send = function (recipient_name, msg)
         send(recipient_name, msg, ctx.thread_id)
-        return coroutine.yield()
+        return coroutine.yield("__suspended__" .. ctx.thread_id)
     end
     ctx.do_send = do_send
     ctx.terminate = terminate

--- a/src/lua/test/test_send_result.lua
+++ b/src/lua/test/test_send_result.lua
@@ -1,0 +1,1 @@
+return ctx.msg .. ' processed'


### PR DESCRIPTION
Previously, `LuaActor` returns `LuaMessage::Nil` when the script yielded. It's hard to distinguish between a completed script and a yielded script.

This PR adds a special message variant to indicate that the script is yielded.